### PR TITLE
Store terminal failures as TerminalParseFailures

### DIFF
--- a/lib/treetop/runtime/compiled_parser.rb
+++ b/lib/treetop/runtime/compiled_parser.rb
@@ -3,7 +3,7 @@ module Treetop
     class CompiledParser
       include Treetop::Runtime
 
-      attr_reader :input, :index, :max_terminal_failure_index
+      attr_reader :input, :index, :max_terminal_failure_index, :terminal_failures
       attr_writer :root
       attr_accessor :consume_all_input
       alias :consume_all_input? :consume_all_input
@@ -50,15 +50,6 @@ module Treetop
                 " at line #{failure_line}, column #{failure_column} (byte #{failure_index+1})" +
                 (failure_index > 0 ? " after #{input[index...failure_index]}" : '')
       end
-
-      def terminal_failures
-        if @terminal_failures.empty? || @terminal_failures[0].is_a?(TerminalParseFailure)
-          @terminal_failures
-        else
-          @terminal_failures.map! {|tf_ary| TerminalParseFailure.new(*tf_ary) }
-        end
-      end
-
 
       protected
 
@@ -118,7 +109,7 @@ module Treetop
           @max_terminal_failure_index = index
           @terminal_failures = []
         end
-        @terminal_failures << [index, expected_string, unexpected]
+        @terminal_failures << TerminalParseFailure.new(index, expected_string, unexpected)
         return nil
       end
     end


### PR DESCRIPTION
When attempting to print out a failure message using `failure_reason`
for my tiny personal project `propose`[1], I was encountering the following error:

    NoMethodError: undefined method `unexpected' for [0, "[a-z]", false]:Array> with backtrace

This started happening after upgrading to `treetop` 1.6.0+.

It looks like the problem here is that terminal failures are stored in
`@terminal_failures` as tuples, and when you call `terminal_failures` it
does a check to see if the first item is a `TerminalParseFailure`, and
converts the list if it isn't. However, if you call `terminal_failures`
multiple times, it's possible other errors were added, and so you'll
have a mixture of `Array` tuples and `TerminalParseFailure`s.

The fix is to store them as `TerminalParseFailure`s when the failure is
first encountered in `terminal_parse_failure`. It's not overly expensive
and allows us to avoid this unnecessary complexity.

[1] https://github.com/sds/propose