### PR TITLE
Update treetop.gemspec

### DIFF
--- a/treetop.gemspec
+++ b/treetop.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/cjheath/treetop"
   spec.licenses = ["MIT"]
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec|website|script|\.|benchmark)}) }
+  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec|Treetop.tmbundle|History.txt|website|script|\.|benchmark)}) }
   spec.executables = ["tt"]
   spec.require_paths = ["lib"]
   spec.extra_rdoc_files = [


### PR DESCRIPTION
Remove unnecessary files from gem

These were added back in with the following commit be6e5321be69b01744d4a272e12a7aca19d6d511

and I do not believe are required.