### PR TITLE
Explicitly declare a string that undergoes mutation is mutable

### DIFF
--- a/lib/treetop/compiler/ruby_builder.rb
+++ b/lib/treetop/compiler/ruby_builder.rb
@@ -9,7 +9,7 @@ module Treetop
       def initialize
         @level = 0
         @address_space = LexicalAddressSpace.new
-        @ruby = ""
+        @ruby = String.new("")
       end
       
       def <<(ruby_line)              


### PR DESCRIPTION
With Ruby's new immutable string literal mode enabled, treetop fails to parse because it is attempting to mutate a string literal. By explicitly declaring this specific string to be mutable we maintain the same behaviour regardless of whether Ruby's literal strings are all immutable or not.

Note, there may be other places in the codebase where this switch is needed. This is the only place I noticed and things are working ok for me after this change.