### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: build
+
+on: [pull_request, push]
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.1'
+          - '3.0'
+          - '2.7'
+          - '2.6'
+          - '2.5'
+          - '2.4'
+          - '2.3'
+          - '2.2'
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,7 @@ source 'https://rubygems.org'
 
 gem "polyglot", "~> 0.3"
 
-group :development do
-  gem "activesupport", "~> 4"
-  gem "i18n", "~> 0.6"
-  gem "rr", "~> 1.0"
-  gem "rspec", "~> 3"
-  gem "rake"
-end
+gemspec
 
 group :website do
   platforms :ruby do

--- a/treetop.gemspec
+++ b/treetop.gemspec
@@ -25,10 +25,10 @@ Gem::Specification.new do |spec|
   ]
 
   spec.add_runtime_dependency(%q<polyglot>, ["~> 0.3"])
-  spec.add_development_dependency(%q<activesupport>, ["~> 4"])
-  spec.add_development_dependency(%q<i18n>, ["~> 0.6"])
-  spec.add_development_dependency(%q<rr>, ["~> 1.0"])
+  spec.add_development_dependency(%q<activesupport>, [">= 4"])
+  spec.add_development_dependency(%q<i18n>, ["~> 1.0"])
+  spec.add_development_dependency(%q<rr>, ["~> 3.0"])
   spec.add_development_dependency(%q<rspec>, ["~> 3"])
-  spec.add_development_dependency(%q<rake>, ["~> 11"])
+  spec.add_development_dependency(%q<rake>, [">= 11"])
 end
 


### PR DESCRIPTION
This PR migrates CI to GitHub Actions, as Travis CI.org is no longer active.  Minor Ruby versions from 2.2 to 3.1 are tested.  So minor adjustment of the Gemfile and gemspec to allow them all to run green.