### PR TITLE
Provide nested parser class for Zeitwerk compat

### DIFF
--- a/lib/treetop/compiler/metagrammar.rb
+++ b/lib/treetop/compiler/metagrammar.rb
@@ -4231,11 +4231,13 @@ module Treetop
         r0
       end
 
+
+      class Parser < Treetop::Runtime::CompiledParser
+        include Metagrammar
+      end
     end
 
-    class MetagrammarParser < Treetop::Runtime::CompiledParser
-      include Metagrammar
-    end
+    MetagrammarParser = Metagrammar::Parser
 
   end
 end

--- a/lib/treetop/compiler/node_classes/grammar.rb
+++ b/lib/treetop/compiler/node_classes/grammar.rb
@@ -3,26 +3,28 @@ module Treetop
     class Grammar < Runtime::SyntaxNode
       def compile
         builder = RubyBuilder.new
-        
+
         builder.module_declaration "#{grammar_name.text_value}" do
           builder.in(indent_level) # account for initial indentation of grammar declaration
           builder << "include Treetop::Runtime"
           builder.newline
           declaration_sequence.compile(builder)
+          builder.newline
+          builder.class_declaration "Parser < Treetop::Runtime::CompiledParser" do
+            builder << "include #{grammar_name.text_value}"
+          end
         end
         builder.newline
-        builder.class_declaration "#{parser_name} < Treetop::Runtime::CompiledParser" do
-          builder << "include #{grammar_name.text_value}"
-        end
+        builder << "#{parser_name} = #{grammar_name.text_value}::Parser"
       end
-      
+
       def indent_level
         input.column_of(interval.begin) - 1
       end
-      
+
       def parser_name
         grammar_name.text_value + 'Parser'
       end
     end
-  end 
+  end
 end

--- a/spec/compiler/grammar_compiler_spec.rb
+++ b/spec/compiler/grammar_compiler_spec.rb
@@ -50,7 +50,7 @@ describe Compiler::GrammarCompiler do
   specify "compilation of a single file without writing it to an output file" do
     compiler.ruby_source(source_path_with_treetop_extension).should_not be_nil
   end
-  
+
   specify "ruby_source_from_string compiles a grammar stored in string" do
     compiler.ruby_source_from_string(File.read(source_path_with_treetop_extension)).should_not be_nil
   end
@@ -60,11 +60,11 @@ describe Compiler::GrammarCompiler do
     Test::GrammarParser.new.parse('foo').should_not be_nil
   end
 
-  specify "Treetop.load compiles and evaluates a source grammar with a .treetop extension" do    
+  specify "Treetop.load compiles and evaluates a source grammar with a .treetop extension" do
     Treetop.load source_path_with_treetop_extension
     Test::GrammarParser.new.parse('foo').should_not be_nil
   end
-  
+
   specify "Treetop.load compiles and evaluates a source grammar with a .tt extension" do
     path_without_extension = source_path_with_tt_extension
     Treetop.load path_without_extension
@@ -76,6 +76,11 @@ describe Compiler::GrammarCompiler do
     path_without_extension = source_path_with_treetop_extension.gsub(/\.treetop\Z/, '')
     Treetop.load path_without_extension
     Test::GrammarParser.new.parse('foo').should_not be_nil
+  end
+
+  specify "Compiles parser also as nested class" do
+    Treetop.load source_path_with_treetop_extension
+    Test::Grammar::Parser.new.parse('foo').should_not be_nil
   end
 
   specify "grammars with 'do' compile" do


### PR DESCRIPTION
Zeitwerk follows the general convention that the file name implies the constant the file will load. Since the compiled Treetop files define two constant one will not end up matching the filename, making it incompatible with reloaders such as Zeitwerk.

To maintain compatibility with existing uses of Treetop we want to maintain the `<Grammar>Parser` constant. But to enable compatibility with the convention that Zeitwerk follows we also want a `<Grammar>::Parser` constant.

Therefore, the compiled code now defines both. First, it defines the nested class within the grammar module. Then it aliases that constant to the existing constant.

This should provide the best of both worlds. Users already using the old constant can continue to do so. But users using auto-loaders like Zeitwerk can now assume the standard naming conventions.

---

In addition to changing the output, I also rebuilt the Treetop grammar so the new constant can be used on the included grammar. I also added a test to verify the new nested class can be used as a parser.

---

My editor auto-removed some unnecessary white-space.

---

This closes #51.