### PR TITLE
Add support for "endless" rule

### DIFF
--- a/lib/treetop/compiler/metagrammar.rb
+++ b/lib/treetop/compiler/metagrammar.rb
@@ -799,13 +799,19 @@ module Treetop
           r1 = SyntaxNode.new(input, (index-1)...index) if r1 == true
           r0 = r1
         else
-          r2 = _nt_include_declaration
+          r2 = _nt_parsing_endless_rule
           if r2
             r2 = SyntaxNode.new(input, (index-1)...index) if r2 == true
             r0 = r2
           else
-            @index = i0
-            r0 = nil
+            r3 = _nt_include_declaration
+            if r3
+              r3 = SyntaxNode.new(input, (index-1)...index) if r3 == true
+              r0 = r3
+            else
+              @index = i0
+              r0 = nil
+            end
           end
         end
 
@@ -1024,6 +1030,188 @@ module Treetop
         end
 
         node_cache[:parsing_rule][start_index] = r0
+
+        r0
+      end
+
+      module ParsingEndlessRule0
+        def nonterminal
+          elements[2]
+        end
+
+        def parsing_expression
+          elements[6]
+        end
+
+      end
+
+      def _nt_parsing_endless_rule
+        start_index = index
+        if node_cache[:parsing_endless_rule].has_key?(index)
+          cached = node_cache[:parsing_endless_rule][index]
+          if cached
+            node_cache[:parsing_endless_rule][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            @index = cached.interval.end
+          end
+          return cached
+        end
+
+        i0, s0 = index, []
+        if (match_len = has_terminal?('rule', false, index))
+          r1 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+          @index += match_len
+        else
+          terminal_parse_failure('\'rule\'')
+          r1 = nil
+        end
+        s0 << r1
+        if r1
+          s2, i2 = [], index
+          loop do
+            if has_terminal?(@regexps[gr = '\A[ \\t]'] ||= Regexp.new(gr), :regexp, index)
+              r3 = true
+              @index += 1
+            else
+              terminal_parse_failure('[ \\t]')
+              r3 = nil
+            end
+            if r3
+              s2 << r3
+            else
+              break
+            end
+          end
+          if s2.empty?
+            @index = i2
+            r2 = nil
+          else
+            r2 = instantiate_node(SyntaxNode,input, i2...index, s2)
+          end
+          s0 << r2
+          if r2
+            r4 = _nt_nonterminal
+            s0 << r4
+            if r4
+              s5, i5 = [], index
+              loop do
+                if has_terminal?(@regexps[gr = '\A[ \\t]'] ||= Regexp.new(gr), :regexp, index)
+                  r6 = true
+                  @index += 1
+                else
+                  terminal_parse_failure('[ \\t]')
+                  r6 = nil
+                end
+                if r6
+                  s5 << r6
+                else
+                  break
+                end
+              end
+              r5 = instantiate_node(SyntaxNode,input, i5...index, s5)
+              s0 << r5
+              if r5
+                if (match_len = has_terminal?('=', false, index))
+                  r7 = true
+                  @index += match_len
+                else
+                  terminal_parse_failure('\'=\'')
+                  r7 = nil
+                end
+                s0 << r7
+                if r7
+                  s8, i8 = [], index
+                  loop do
+                    if has_terminal?(@regexps[gr = '\A[ \\t]'] ||= Regexp.new(gr), :regexp, index)
+                      r9 = true
+                      @index += 1
+                    else
+                      terminal_parse_failure('[ \\t]')
+                      r9 = nil
+                    end
+                    if r9
+                      s8 << r9
+                    else
+                      break
+                    end
+                  end
+                  r8 = instantiate_node(SyntaxNode,input, i8...index, s8)
+                  s0 << r8
+                  if r8
+                    r10 = _nt_parsing_expression
+                    s0 << r10
+                    if r10
+                      i11 = index
+                      r12 = lambda { |v| v.first.text_value !~ /[\n\r]/ }.call(s0)
+                      if !r12
+                        terminal_parse_failure("<semantic predicate>")
+                      end
+                      if r12
+                        @index = i11
+                        r11 = instantiate_node(SyntaxNode,input, index...index)
+                      else
+                        @index = i11
+                        r11 = nil
+                      end
+                      s0 << r11
+                      if r11
+                        s13, i13 = [], index
+                        loop do
+                          i14 = index
+                          if has_terminal?(@regexps[gr = '\A[ \\t]'] ||= Regexp.new(gr), :regexp, index)
+                            r15 = true
+                            @index += 1
+                          else
+                            terminal_parse_failure('[ \\t]')
+                            r15 = nil
+                          end
+                          if r15
+                            r15 = SyntaxNode.new(input, (index-1)...index) if r15 == true
+                            r14 = r15
+                          else
+                            r16 = _nt_comment_to_eol
+                            if r16
+                              r16 = SyntaxNode.new(input, (index-1)...index) if r16 == true
+                              r14 = r16
+                            else
+                              @index = i14
+                              r14 = nil
+                            end
+                          end
+                          if r14
+                            s13 << r14
+                          else
+                            break
+                          end
+                        end
+                        r13 = instantiate_node(SyntaxNode,input, i13...index, s13)
+                        s0 << r13
+                        if r13
+                          if has_terminal?(@regexps[gr = '\A[\\n\\r]'] ||= Regexp.new(gr), :regexp, index)
+                            r17 = true
+                            @index += 1
+                          else
+                            terminal_parse_failure('[\\n\\r]')
+                            r17 = nil
+                          end
+                          s0 << r17
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+        if s0.last
+          r0 = instantiate_node(ParsingRule,input, i0...index, s0)
+          r0.extend(ParsingEndlessRule0)
+        else
+          @index = i0
+          r0 = nil
+        end
+
+        node_cache[:parsing_endless_rule][start_index] = r0
 
         r0
       end

--- a/lib/treetop/compiler/metagrammar.treetop
+++ b/lib/treetop/compiler/metagrammar.treetop
@@ -55,7 +55,7 @@ module Treetop
       end
 
       rule declaration
-        parsing_rule / include_declaration
+        parsing_rule / parsing_endless_rule / include_declaration
       end
 
       rule include_declaration
@@ -68,6 +68,10 @@ module Treetop
 
       rule parsing_rule
         'rule' space nonterminal space ('do' space)? parsing_expression space 'end' <ParsingRule>
+      end
+
+      rule parsing_endless_rule
+        'rule' [ \t]+ nonterminal [ \t]* '=' [ \t]* parsing_expression &{ |v| v.first.text_value !~ /[\n\r]/ } ([ \t] / comment_to_eol)* [\n\r] <ParsingRule>
       end
 
       rule parsing_expression

--- a/spec/compiler/parsing_rule_spec.rb
+++ b/spec/compiler/parsing_rule_spec.rb
@@ -15,23 +15,23 @@ module ParsingRuleSpec
       parser = self.class.const_get(:FooParser).new
       parser.send(:prepare_to_parse, 'baz')
       node_cache = parser.send(:node_cache)
-    
+
       node_cache[:bar][0].should be_nil
-    
+
       parser._nt_bar
-    
-      cached_node = node_cache[:bar][0]        
+
+      cached_node = node_cache[:bar][0]
       cached_node.should be_an_instance_of(Runtime::SyntaxNode)
       cached_node.text_value.should == 'baz'
-    
+
       parser.instance_eval { @index = 0 }
       parser._nt_bar.should equal(cached_node)
       parser.index.should == cached_node.interval.end
     end
   end
-  
-  
-  describe "a grammar with choice that uses the cache and has a subsequent expression" do    
+
+
+  describe "a grammar with choice that uses the cache and has a subsequent expression" do
     testing_grammar %{
       grammar Logic
         rule expression
@@ -51,11 +51,26 @@ module ParsingRuleSpec
         end
       end
     }
-    
+
     it "parses a single-character value and generates a node from the cache" do
       result = parse('a')
       result.should be_a(Treetop::Runtime::SyntaxNode)
       result.elements.should be_nil
+    end
+  end
+
+  describe "a grammar using an endless rule" do
+    testing_grammar %{
+      grammar EndlessRule
+        rule foo = bar
+        rule bar=baz
+        rule baz = 'boo' # comment
+      end
+    }
+
+    it "parses" do
+      result = parse('boo')
+      result.should_not be_nil
     end
   end
 end


### PR DESCRIPTION
This is similar to Ruby's "endless" method. The goal is to allow simple rules to be more compact (similar also to JavaScript's bracket-less arrow functions).

Being more compact (while still readable) allows more code to be seen at once and reduces keyword noise (lots of `end`s) and excess white space. These two things make it easier to scan and grok the grammar.

I've tested this in a project I am using Treetop for. It reduced the LOC for the Treetop files by 1/4 since a significant number of the rules were simple and could be expressed on a single line. This significantly reduced the scrolling to read the grammar.

This closes #54. See that issue for examples.