### PR TITLE
Ensure endless rules are on a single line

### DIFF
--- a/spec/compiler/parsing_rule_spec.rb
+++ b/spec/compiler/parsing_rule_spec.rb
@@ -72,5 +72,16 @@ module ParsingRuleSpec
       result = parse('boo')
       result.should_not be_nil
     end
+
+    context "breaking rule defination" do
+      it "does not parse" do
+        compiling_grammar(%{
+          grammar EndlessRule
+            rule foo = ('should'
+              ' fail')
+          end
+        }).should raise_error RuntimeError
+      end
+    end
   end
 end


### PR DESCRIPTION
In 7df506e I had added an endless rule but I made a mistake in the semantic predicate. I examined the first token (aka `'rule'`) and not the last one (the "parsing expression").

@cjhealth fixed it up for me in 229d2c8 but it seems prudent to add a test to verify this.

This commit adds this test. If I update the test replacing the newline with just a normal space between the literals then test fails. But with the newline in the parsing expression the test passes (i.e. it fails to parse).