### PR TITLE
CI: use a supported Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on: [pull_request, push]
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The previous run in CI failed due to the Ubuntu not being supported in the runner. 

Let's see how this fares. Update: this gets us to green. 