### PR TITLE
Honor SOURCE_DATE_EPOCH for reproducible builds

### DIFF
--- a/treetop.gemspec
+++ b/treetop.gemspec
@@ -10,7 +10,16 @@ Gem::Specification.new do |spec|
   spec.authors = ["Nathan Sobo", "Clifford Heath"]
 
   spec.email = "cliffordheath@gmail.com"
-  spec.date = Date.today.strftime("%F")
+
+  # Honor SOURCE_DATE_EPOCH for reproducible builds
+  source_date_epoch = ENV['SOURCE_DATE_EPOCH']
+  spec.date =
+    if source_date_epoch
+      Time.at(Integer(source_date_epoch)).utc.strftime("%F")
+    else
+      Date.today.strftime("%F")
+    end
+
   spec.summary = "A Ruby-based text parsing and interpretation DSL"
   spec.description = "A Parsing Expression Grammar (PEG) Parser generator DSL for Ruby"
   spec.homepage = "https://github.com/cjheath/treetop"


### PR DESCRIPTION
Gathering the current date results in a non-determistic information record, which prevents [reproducible builds](https://reproducible-builds.org/) (see [this diffoscope output](https://bpa.st/5GFX4)).

This commit sets `spec.date` to the value of the [SOURCE_DATE_EPOCH environment variable](https://reproducible-builds.org/docs/source-date-epoch/) if it is set (which should be done in every build environment that expects reproducible builds).