### PR TITLE
Fix race condition in constant removal from commit 62ca923

### DIFF
--- a/lib/treetop/compiler/metagrammar.rb
+++ b/lib/treetop/compiler/metagrammar.rb
@@ -4457,7 +4457,7 @@ module Treetop
       end
     end
 
-    remove_const(:MetagrammarParser) if const_defined?(:MetagrammarParser); MetagrammarParser = Metagrammar::Parser
+    (remove_const(:MetagrammarParser) if const_defined?(:MetagrammarParser)) rescue nil; MetagrammarParser = Metagrammar::Parser
 
   end
 end

--- a/lib/treetop/compiler/node_classes/grammar.rb
+++ b/lib/treetop/compiler/node_classes/grammar.rb
@@ -15,7 +15,7 @@ module Treetop
           end
         end
         builder.newline
-        builder << "remove_const(:#{parser_name}) if const_defined?(:#{parser_name}); #{parser_name} = #{grammar_name.text_value}::Parser"
+        builder << "(remove_const(:#{parser_name}) if const_defined?(:#{parser_name})) rescue nil; #{parser_name} = #{grammar_name.text_value}::Parser"
       end
 
       def indent_level


### PR DESCRIPTION
After 62ca923 intermittent issues are showing up in test suites with NoMethodErrors. It looks like maybe there is a race condition with removing/replacing constants. This patch attempts to fix that by adding a rescue for the case where a constant has been successfully removed. This should replace the old behavior where the constant is replaced.


**Repro details**
Using jruby I have a simple script that triggers this (i think, its not the same NoMethodError but I think the NameError is a similar symptom):
```
➜  treetop ruby -v
jruby 9.4.13.0 (3.1.4) 2025-06-10 9938a3461f OpenJDK 64-Bit Server VM 21.0.6 on 21.0.6 +jit [arm64-darwin]
➜  treetop cat repro.rb
require 'treetop'

code = <<-GRAMMAR
grammar TestGrammar
  rule simple
    'hello'
  end
end
GRAMMAR

threads = 50.times.map do
  Thread.new do
    100.times { Treetop.load_from_string(code) }
  end
end
threads.each(&:join)

➜  treetop ruby repro.rb
warning: thread "Ruby-0-Thread-24: repro.rb:12" terminated with exception (report_on_exception is true):NameError: cannot remove TestGrammarParser for Object
      remove_const at org/jruby/RubyModule.java:4343
            (eval) at (eval):38
       module_eval at org/jruby/RubyModule.java:3730
  load_from_string at /Users/cas/.rbenv/versions/jruby-9.4.13.0/lib/ruby/gems/shared/gems/treetop-1.6.17/lib/treetop/compiler/grammar_compiler.rb:50
            <main> at repro.rb:13
             times at org/jruby/RubyFixnum.java:305
            <main> at repro.rb:13
NameError: cannot remove TestGrammarParser for Object
      remove_const at org/jruby/RubyModule.java:4343
            (eval) at (eval):38
       module_eval at org/jruby/RubyModule.java:3730
  load_from_string at /Users/cas/.rbenv/versions/jruby-9.4.13.0/lib/ruby/gems/shared/gems/treetop-1.6.17/lib/treetop/compiler/grammar_compiler.rb:50
            <main> at repro.rb:13
             times at org/jruby/RubyFixnum.java:305
            <main> at repro.rb:13
```

I've been seeing failures (example below) in [logstash](https://github.com/elastic/logstash/blob/4abb46c453c6454abfe4dd92edfa68779538547f/logstash-core/lib/logstash/compiler/lscl/lscl_grammar.rb#L3620)
```

2025-11-12 12:01:05 PST | ConfigCompilerTest > testConfigDuplicateBlocksToPipelineIR FAILED
  | 2025-11-12 12:01:05 PST | org.jruby.exceptions.NoMethodError: (NoMethodError) undefined method `const_defined?' for main:Object
  | 2025-11-12 12:01:05 PST | at RUBY.<main>(/buildkite/builds/bk-agent-prod-k8s-1762977525911157838/elastic/logstash-pull-request-pipeline/logstash-core/lib/logstash/compiler/lscl/lscl_grammar.rb:3620)
  | 2025-11-12 12:01:05 PST | at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:1187)
  | 2025-11-12 12:01:05 PST | at buildkite.builds.bk_minus_agent_minus_prod_minus_k8s_minus_1762977525911157838.elastic.logstash_minus_pull_minus_request_minus_pipeline.vendor.jruby.lib.ruby.stdlib.rubygems.core_ext.kernel_require.require(/buildkite/builds/bk-agent-prod-k8s-1762977525911157838/elastic/logstash-pull-request-pipeline/vendor/jruby/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:144)
  | 2025-11-12 12:01:05 PST | at RUBY.<main>(/buildkite/builds/bk-agent-prod-k8s-1762977525911157838/elastic/logstash-pull-request-pipeline/logstash-core/lib/logstash/compiler.rb:18)
  | 2025-11-12 12:01:05 PST | at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:1187)
  | 2025-11-12 12:01:05 PST | at buildkite.builds.bk_minus_agent_minus_prod_minus_k8s_minus_1762977525911157838.elastic.logstash_minus_pull_minus_request_minus_pipeline.vendor.jruby.lib.ruby.stdlib.rubygems.core_ext.kernel_require.require(/buildkite/builds/bk-agent-prod-k8s-1762977525911157838/elastic/logstash-pull-request-pipeline/vendor/jruby/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:144)
  | 2025-11-12 12:01:05 PST | at RUBY.<main>(:1)
  | 2025-11-12 12:01:05 PST |  

<br class="Apple-interchange-newline">
```
